### PR TITLE
フィールドの色による勝敗処理を追加

### DIFF
--- a/UnityProject/Assets/Data/OverallCamera.renderTexture
+++ b/UnityProject/Assets/Data/OverallCamera.renderTexture
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!84 &8400000
+RenderTexture:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: OverallCamera
+  m_ImageContentsHash:
+    serializedVersion: 2
+    Hash: 00000000000000000000000000000000
+  m_Width: 256
+  m_Height: 256
+  m_AntiAliasing: 1
+  m_DepthFormat: 2
+  m_ColorFormat: 0
+  m_MipMap: 0
+  m_GenerateMips: 1
+  m_SRGB: 0
+  m_TextureSettings:
+    serializedVersion: 2
+    m_FilterMode: 1
+    m_Aniso: 0
+    m_MipBias: 0
+    m_WrapU: 1
+    m_WrapV: 1
+    m_WrapW: 1
+  m_Dimension: 2
+  m_VolumeDepth: 1

--- a/UnityProject/Assets/Data/OverallCamera.renderTexture.meta
+++ b/UnityProject/Assets/Data/OverallCamera.renderTexture.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 3e012c2def672d9438a87282741f519c
+timeCreated: 1508834824
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 8400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Data/TeamColor.asset
+++ b/UnityProject/Assets/Data/TeamColor.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f347a41e6aa91f34f90fefd8b74c127b, type: 3}
+  m_Name: TeamColor
+  m_EditorClassIdentifier: 
+  TeamColor1: {r: 1, g: 0, b: 0, a: 1}
+  TeamColor2: {r: 0, g: 0, b: 1, a: 1}

--- a/UnityProject/Assets/Data/TeamColor.asset.meta
+++ b/UnityProject/Assets/Data/TeamColor.asset.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: b41ad7b4aaf01444d8be5e24daa3667e
+timeCreated: 1508838685
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/InkPainter/Resources/Es.InkPainter.PaintMain.mat
+++ b/UnityProject/Assets/InkPainter/Resources/Es.InkPainter.PaintMain.mat
@@ -61,7 +61,7 @@ Material:
     m_Floats:
     - INK_PAINTER_COLOR_BLEND: 0
     - TEXTURE_PAINT_COLOR_BLEND: 0
-    - _BrushScale: 0
+    - _BrushScale: 0.1
     - _BumpScale: 1
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
@@ -82,4 +82,4 @@ Material:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _ControlColor: {r: 0, g: 0.08965492, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _PaintUV: {r: 0.5, g: 0.35040325, b: 0, a: 0}
+    - _PaintUV: {r: 0.5, g: 0.7590152, b: 0, a: 0}

--- a/UnityProject/Assets/InkPainter/Sample/Resource/Material/Test.mat
+++ b/UnityProject/Assets/InkPainter/Sample/Resource/Material/Test.mat
@@ -6,9 +6,9 @@ Material:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_Name: Es.InkPainter.PaintNormal
-  m_Shader: {fileID: 4800000, guid: 56ff45392b7f63c46a91393a4167ebcc, type: 3}
-  m_ShaderKeywords: INK_PAINTER_NORMAL_BLEND_USE_BRUSH
+  m_Name: Test
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: _EMISSION _NORMALMAP _PARALLAXMAP
   m_LightmapFlags: 1
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -18,16 +18,8 @@ Material:
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
-    - _Brush:
-        m_Texture: {fileID: 10300, guid: 0000000000000000f000000000000000, type: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _BrushNormal:
-        m_Texture: {fileID: 2800000, guid: 945b831b22eb06945bf77e00f16ff51a, type: 3}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
     - _BumpMap:
-        m_Texture: {fileID: 0}
+        m_Texture: {fileID: 2800000, guid: caa85b3e66828384c90a547928136183, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _DetailAlbedoMap:
@@ -47,7 +39,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 0}
+        m_Texture: {fileID: 2800000, guid: 3b3cc70fb15573543b2307f0b83d5c24, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:
@@ -59,25 +51,21 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _ParallaxMap:
-        m_Texture: {fileID: 0}
+        m_Texture: {fileID: 2800000, guid: 3b3cc70fb15573543b2307f0b83d5c24, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats:
-    - INK_PAINTER_NORMAL_BLEND: 0
-    - TEXTURE_PAINT_NORMAL_BLEND: 0
-    - _BrushScale: 0.1
     - _BumpScale: 1
-    - _Cutoff: 0.5
+    - _Cutoff: 0.554
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
     - _GlossMapScale: 1
-    - _Glossiness: 0.5
+    - _Glossiness: 0
     - _GlossyReflections: 1
     - _Metallic: 0
     - _Mode: 0
-    - _NormalBlend: 0.15
-    - _OcclusionStrength: 1
-    - _Parallax: 0.02
+    - _OcclusionStrength: 0.214
+    - _Parallax: 0.0595
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
@@ -86,4 +74,3 @@ Material:
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _PaintUV: {r: 0.5, g: 0.7590152, b: 0, a: 0}

--- a/UnityProject/Assets/InkPainter/Sample/Resource/Material/Test.mat.meta
+++ b/UnityProject/Assets/InkPainter/Sample/Resource/Material/Test.mat.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 003423aac9c5cdd44986e5203e3b2633
+timeCreated: 1508987528
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefab/OverallCamera 1.prefab
+++ b/UnityProject/Assets/Prefab/OverallCamera 1.prefab
@@ -1,0 +1,116 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1428184578526760}
+  m_IsPrefabParent: 1
+--- !u!1 &1428184578526760
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4211235972627236}
+  - component: {fileID: 20008581615570468}
+  - component: {fileID: 124391439634577780}
+  - component: {fileID: 92074008046498672}
+  - component: {fileID: 81565865912323154}
+  - component: {fileID: 114787185832726060}
+  m_Layer: 0
+  m_Name: OverallCamera 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4211235972627236
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1428184578526760}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 433.8, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!20 &20008581615570468
+Camera:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1428184578526760}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.5176471, g: 0.63529414, b: 0.7843138, a: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 49
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967039
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 8400000, guid: 3e012c2def672d9438a87282741f519c, type: 2}
+  m_TargetDisplay: 3
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+  m_StereoMirrorMode: 0
+--- !u!81 &81565865912323154
+AudioListener:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1428184578526760}
+  m_Enabled: 1
+--- !u!92 &92074008046498672
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1428184578526760}
+  m_Enabled: 1
+--- !u!114 &114787185832726060
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1428184578526760}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 44b354413ae09d94999eee97b2b0dda8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  overallCamera: {fileID: 20008581615570468}
+  teamColor: {fileID: 11400000, guid: b41ad7b4aaf01444d8be5e24daa3667e, type: 2}
+--- !u!124 &124391439634577780
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1428184578526760}
+  m_Enabled: 1

--- a/UnityProject/Assets/Prefab/OverallCamera 1.prefab.meta
+++ b/UnityProject/Assets/Prefab/OverallCamera 1.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: f272f6fac6faf124f893da077626cd9d
+timeCreated: 1508836712
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefab/OverallCameraTexture 1.prefab
+++ b/UnityProject/Assets/Prefab/OverallCameraTexture 1.prefab
@@ -1,0 +1,94 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1103131638069048}
+  m_IsPrefabParent: 1
+--- !u!1 &1103131638069048
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224478945533289148}
+  - component: {fileID: 222445206985365924}
+  - component: {fileID: 114762218387988000}
+  - component: {fileID: 114136318266810484}
+  m_Layer: 0
+  m_Name: OverallCameraTexture 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &114136318266810484
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1103131638069048}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 44b354413ae09d94999eee97b2b0dda8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  overallCamera: {fileID: 0}
+  teamColor: {fileID: 11400000, guid: b41ad7b4aaf01444d8be5e24daa3667e, type: 2}
+--- !u!114 &114762218387988000
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1103131638069048}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -98529514, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Texture: {fileID: 8400000, guid: 3e012c2def672d9438a87282741f519c, type: 2}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &222445206985365924
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1103131638069048}
+--- !u!224 &224478945533289148
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1103131638069048}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}

--- a/UnityProject/Assets/Prefab/OverallCameraTexture 1.prefab.meta
+++ b/UnityProject/Assets/Prefab/OverallCameraTexture 1.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 12afaa3f36d0ff64c824510c349cacf5
+timeCreated: 1508999043
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefab/Plane.prefab
+++ b/UnityProject/Assets/Prefab/Plane.prefab
@@ -1,0 +1,116 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1937282727658254}
+  m_IsPrefabParent: 1
+--- !u!1 &1937282727658254
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4849819245966802}
+  - component: {fileID: 33121265802747154}
+  - component: {fileID: 64789255007639498}
+  - component: {fileID: 23695462635894324}
+  - component: {fileID: 114658422124987474}
+  m_Layer: 0
+  m_Name: Plane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4849819245966802
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1937282727658254}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 50, y: 1, z: 50}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &23695462635894324
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1937282727658254}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: fb1d428ef3e299142914e9a70d56de93, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &33121265802747154
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1937282727658254}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!64 &64789255007639498
+MeshCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1937282727658254}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Convex: 0
+  m_InflateMesh: 0
+  m_SkinWidth: 0.01
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &114658422124987474
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1937282727658254}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 04cc1b9412eea6e4a8798f4b2f88b4ad, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  paintSet:
+  - mainTextureName: _MainTex
+    normalTextureName: _BumpMap
+    heightTextureName: _ParallaxMap
+    useMainPaint: 1
+    useNormalPaint: 1
+    useHeightPaint: 0

--- a/UnityProject/Assets/Prefab/Plane.prefab.meta
+++ b/UnityProject/Assets/Prefab/Plane.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 273079b46d5dd6c498246d2c58a32faa
+timeCreated: 1508831773
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Prefab/Player.prefab
+++ b/UnityProject/Assets/Prefab/Player.prefab
@@ -38,6 +38,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4319366648230832}
   - component: {fileID: 114946910104538304}
+  - component: {fileID: 114221890494299444}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -70,7 +71,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1792064698479406}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 65.48, z: -311.8}
+  m_LocalPosition: {x: 0, y: 65.48, z: -131}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4413183735936676}
@@ -194,6 +195,29 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &114221890494299444
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1792064698479406}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5446660f2a3446a428bace97748e8a23, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  brush:
+    brushTexture: {fileID: 10300, guid: 0000000000000000f000000000000000, type: 0}
+    brushNormalTexture: {fileID: 2800000, guid: 945b831b22eb06945bf77e00f16ff51a,
+      type: 3}
+    brushHeightTexture: {fileID: 0}
+    brushScale: 0.1
+    brushNormalBlend: 0.15
+    brushHeightBlend: 0
+    brushColor: {r: 0, g: 0.08965492, b: 1, a: 1}
+    colorBlendType: 0
+    normalBlendType: 0
+    heightBlendType: 0
 --- !u!114 &114946910104538304
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/UnityProject/Assets/Scenes/game.unity
+++ b/UnityProject/Assets/Scenes/game.unity
@@ -108,6 +108,53 @@ NavMeshSettings:
     tileSize: 256
     accuratePlacement: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &34473236
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4849819245966802, guid: 273079b46d5dd6c498246d2c58a32faa, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4849819245966802, guid: 273079b46d5dd6c498246d2c58a32faa, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4849819245966802, guid: 273079b46d5dd6c498246d2c58a32faa, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4849819245966802, guid: 273079b46d5dd6c498246d2c58a32faa, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4849819245966802, guid: 273079b46d5dd6c498246d2c58a32faa, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4849819245966802, guid: 273079b46d5dd6c498246d2c58a32faa, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4849819245966802, guid: 273079b46d5dd6c498246d2c58a32faa, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4849819245966802, guid: 273079b46d5dd6c498246d2c58a32faa, type: 2}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 23695462635894324, guid: 273079b46d5dd6c498246d2c58a32faa,
+        type: 2}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 003423aac9c5cdd44986e5203e3b2633, type: 2}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 273079b46d5dd6c498246d2c58a32faa, type: 2}
+  m_IsPrefabParent: 0
 --- !u!1001 &144562068
 Prefab:
   m_ObjectHideFlags: 0
@@ -145,7 +192,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4994043480376602, guid: 2098ba7d6859274498b83057a79ec1e7, type: 2}
       propertyPath: m_RootOrder
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 4994043480376602, guid: 2098ba7d6859274498b83057a79ec1e7, type: 2}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -175,7 +222,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 4294967295
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!154 &296228719
 TerrainCollider:
   m_ObjectHideFlags: 0
@@ -224,11 +271,11 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 296228718}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -250, y: 0, z: -250}
+  m_LocalPosition: {x: -250, y: -10, z: -250}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &433425201
 Prefab:
@@ -247,7 +294,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4319366648230832, guid: 1b5fe8aafc1068a4ab9496c252790824, type: 2}
       propertyPath: m_LocalPosition.z
-      value: -311.8
+      value: -131
       objectReference: {fileID: 0}
     - target: {fileID: 4319366648230832, guid: 1b5fe8aafc1068a4ab9496c252790824, type: 2}
       propertyPath: m_LocalRotation.x
@@ -267,8 +314,43 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4319366648230832, guid: 1b5fe8aafc1068a4ab9496c252790824, type: 2}
       propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 23595099792931666, guid: 1b5fe8aafc1068a4ab9496c252790824,
+        type: 2}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+    - target: {fileID: 4413183735936676, guid: 1b5fe8aafc1068a4ab9496c252790824, type: 2}
+      propertyPath: m_LocalScale.x
+      value: 25.487345
+      objectReference: {fileID: 0}
+    - target: {fileID: 4413183735936676, guid: 1b5fe8aafc1068a4ab9496c252790824, type: 2}
+      propertyPath: m_LocalScale.y
+      value: 25.487337
+      objectReference: {fileID: 0}
+    - target: {fileID: 4413183735936676, guid: 1b5fe8aafc1068a4ab9496c252790824, type: 2}
+      propertyPath: m_LocalScale.z
+      value: 25.487337
+      objectReference: {fileID: 0}
+    - target: {fileID: 1702227231790806, guid: 1b5fe8aafc1068a4ab9496c252790824, type: 2}
+      propertyPath: m_Layer
       value: 8
       objectReference: {fileID: 0}
+    - target: {fileID: 1792064698479406, guid: 1b5fe8aafc1068a4ab9496c252790824, type: 2}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1884345844337582, guid: 1b5fe8aafc1068a4ab9496c252790824, type: 2}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 114221890494299444, guid: 1b5fe8aafc1068a4ab9496c252790824,
+        type: 2}
+      propertyPath: teamColor
+      value: 
+      objectReference: {fileID: 11400000, guid: b41ad7b4aaf01444d8be5e24daa3667e,
+        type: 2}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 1b5fe8aafc1068a4ab9496c252790824, type: 2}
   m_IsPrefabParent: 0
@@ -344,6 +426,11 @@ CanvasRenderer:
     type: 2}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 510719161}
+--- !u!224 &597814229 stripped
+RectTransform:
+  m_PrefabParentObject: {fileID: 224478945533289148, guid: 12afaa3f36d0ff64c824510c349cacf5,
+    type: 2}
+  m_PrefabInternal: {fileID: 1469670514}
 --- !u!1 &636422607
 GameObject:
   m_ObjectHideFlags: 0
@@ -407,7 +494,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!1 &673763350
 GameObject:
@@ -563,8 +650,9 @@ RectTransform:
   - {fileID: 510719162}
   - {fileID: 1626548020}
   - {fileID: 836716737}
+  - {fileID: 597814229}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -3972,7 +4060,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!1001 &1066427785
 Prefab:
@@ -4011,7 +4099,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4270486166232260, guid: b74f866418b69a742a98b76742ae24b1, type: 2}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 4270486166232260, guid: b74f866418b69a742a98b76742ae24b1, type: 2}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -4114,6 +4202,129 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1469670514
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 673763357}
+    m_Modifications:
+    - target: {fileID: 224478945533289148, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224478945533289148, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224478945533289148, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224478945533289148, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224478945533289148, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224478945533289148, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224478945533289148, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224478945533289148, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 224478945533289148, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: -100
+      objectReference: {fileID: 0}
+    - target: {fileID: 224478945533289148, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: -100
+      objectReference: {fileID: 0}
+    - target: {fileID: 224478945533289148, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 224478945533289148, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 224478945533289148, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224478945533289148, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224478945533289148, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224478945533289148, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224478945533289148, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224478945533289148, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 114136318266810484, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: overallCamera
+      value: 
+      objectReference: {fileID: 1477110570}
+    - target: {fileID: 1103131638069048, guid: 12afaa3f36d0ff64c824510c349cacf5, type: 2}
+      propertyPath: m_Name
+      value: OverallCameraTexture
+      objectReference: {fileID: 0}
+    - target: {fileID: 114762218387988000, guid: 12afaa3f36d0ff64c824510c349cacf5,
+        type: 2}
+      propertyPath: m_Color.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1103131638069048, guid: 12afaa3f36d0ff64c824510c349cacf5, type: 2}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 12afaa3f36d0ff64c824510c349cacf5, type: 2}
+  m_IsPrefabParent: 0
+--- !u!20 &1477110570 stripped
+Camera:
+  m_PrefabParentObject: {fileID: 20008581615570468, guid: f272f6fac6faf124f893da077626cd9d,
+    type: 2}
+  m_PrefabInternal: {fileID: 1926001771}
 --- !u!1 &1626548019
 GameObject:
   m_ObjectHideFlags: 0
@@ -4280,7 +4491,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1859494737
 GameObject:
@@ -4342,8 +4553,54 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1926001771
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4211235972627236, guid: f272f6fac6faf124f893da077626cd9d, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4211235972627236, guid: f272f6fac6faf124f893da077626cd9d, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 433.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4211235972627236, guid: f272f6fac6faf124f893da077626cd9d, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4211235972627236, guid: f272f6fac6faf124f893da077626cd9d, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 4211235972627236, guid: f272f6fac6faf124f893da077626cd9d, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4211235972627236, guid: f272f6fac6faf124f893da077626cd9d, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4211235972627236, guid: f272f6fac6faf124f893da077626cd9d, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 4211235972627236, guid: f272f6fac6faf124f893da077626cd9d, type: 2}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1428184578526760, guid: f272f6fac6faf124f893da077626cd9d, type: 2}
+      propertyPath: m_Name
+      value: OverallCamera
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: f272f6fac6faf124f893da077626cd9d, type: 2}
+  m_IsPrefabParent: 0
 --- !u!1 &1980803550
 GameObject:
   m_ObjectHideFlags: 0
@@ -4544,7 +4801,7 @@ ParticleSystem:
   moveWithTransform: 0
   moveWithCustomTransform: {fileID: 0}
   scalingMode: 1
-  randomSeed: -2116620832
+  randomSeed: 373052700
   InitialModule:
     serializedVersion: 3
     enabled: 1
@@ -7758,5 +8015,5 @@ Transform:
   m_LocalScale: {x: 10, y: 10, z: 10}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}

--- a/UnityProject/Assets/Script/CameraToTexture.cs
+++ b/UnityProject/Assets/Script/CameraToTexture.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CameraToTexture : MonoBehaviour {
+
+	// Use this for initialization
+	void Start () {
+		
+	}
+	
+	// Update is called once per frame
+	void Update () {
+		
+	}
+}

--- a/UnityProject/Assets/Script/CameraToTexture.cs.meta
+++ b/UnityProject/Assets/Script/CameraToTexture.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d41eca17bd108d04786247d3f204dd97
+timeCreated: 1508834183
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Script/Paint.cs
+++ b/UnityProject/Assets/Script/Paint.cs
@@ -9,10 +9,13 @@ namespace Es.InkPainter.Sample
         [SerializeField]
         private Brush brush;
 
+        //[SerializeField]
+        //TeamColor teamColor = null;
+
         // Use this for initialization
         void Start()
         {
-
+            //brush.Color = teamColor.TeamColor1;
         }
 
         // Update is called once per frame

--- a/UnityProject/Assets/Script/PixelColor.cs
+++ b/UnityProject/Assets/Script/PixelColor.cs
@@ -1,40 +1,102 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-
+using UnityEngine.UI;
 
 public class PixelColor : MonoBehaviour
 {
+	private const float NEARCOLOR = 0.25f;
 
-    public Camera dispCamera;
-    private Texture2D targetTexture;
+	public Camera overallCamera;
 
-    // Use this for initialization
-    void Start()
-    {
-        // テクスチャ取得
-        Texture2D mainTexture = (Texture2D)GetComponent<Renderer>().material.mainTexture;   // 本番は地面を向いているカメラからtargetTextureでテクスチャを作る
-        int red = 0;
-        int blue = 0;
 
-        
-        var tex = dispCamera.targetTexture;
-        targetTexture = new Texture2D(tex.width, tex.height, TextureFormat.ARGB32, false);
+	[SerializeField]
+	TeamColor teamColor = null;
 
-        // 取得したテクスチャのすべてのピクセルの色情報を取得
-        Color[] colors = mainTexture.GetPixels();
-        for (int i = 0; i < colors.Length; i++)
-        {
+	// Use this for initialization
+	void Start()
+	{
 
-            if (colors[i].r > 0.75f && colors[i].g < 0.25f && colors[i].b < 0.25f)
-            {
-                red++;
-            }
-            else if (colors[i].r < 0.25f && colors[i].g < 0.25f && colors[i].b > 0.75f)
-            {
-                blue++;
-            }
-        }
-    }
+	}
+	// Update is called once per frame
+	void Update()
+	{
+		// クリック時（ゲームの流れが完成したらゲーム終了時に）
+		if (Input.GetMouseButtonDown(0))
+		{
+			CalcPixelColor();
+
+		}
+
+	}
+
+	// 色の比率を計算する関数
+	void CalcPixelColor()
+	{
+		Texture2D tex = new Texture2D(256, 256, TextureFormat.RGB24, false);
+
+		// ofc you probably don't have a class that is called CameraController :P
+		Camera activeCamera = overallCamera;
+
+		// Initialize and render
+		RenderTexture rt = new RenderTexture(256, 256, 24);
+		activeCamera.targetTexture = rt;
+		activeCamera.Render();
+		RenderTexture.active = rt;
+
+		// Read pixels
+		tex.ReadPixels(new Rect(0, 0, tex.width, tex.height), 0, 0);
+
+		// 取得したテクスチャのすべてのピクセルの色情報を取得
+		Color[] colors = tex.GetPixels();
+
+		// 得点（仮）
+		int team1Score = 0;
+		int team2Score = 0;
+		//int otherColor = 0;
+		for (int i = 0; i < colors.Length; i++)
+		{
+			if ((colors[i].r > (teamColor.TeamColor1.r - NEARCOLOR) && colors[i].r < (teamColor.TeamColor1.r + NEARCOLOR)) &&
+				(colors[i].g > (teamColor.TeamColor1.g - NEARCOLOR) && colors[i].g < (teamColor.TeamColor1.g + NEARCOLOR)) &&
+				(colors[i].b > (teamColor.TeamColor1.b - NEARCOLOR) && colors[i].b < (teamColor.TeamColor1.b + NEARCOLOR)))
+			{
+				team1Score++;
+			}
+			/*else */
+			if ((colors[i].r > (teamColor.TeamColor2.r - NEARCOLOR) && colors[i].r < (teamColor.TeamColor2.r + NEARCOLOR)) &&
+			(colors[i].g > (teamColor.TeamColor2.g - NEARCOLOR) && colors[i].g < (teamColor.TeamColor2.g + NEARCOLOR)) &&
+			(colors[i].b > (teamColor.TeamColor2.b - NEARCOLOR) && colors[i].b < (teamColor.TeamColor2.b + NEARCOLOR)))
+			{
+				team2Score++;
+			}
+			//else
+			//{
+			//    otherColor++;
+			//}
+		}
+
+		int ratio1Score = 0;
+		int ratio2Score = 0;
+		//float ratio1Score = 0;
+		//float ratio2Score = 0;
+
+		// チーム１＋チーム２＝１００（塗られていない場所は関与しない）
+		ratio1Score = (team1Score * 100) / (team1Score + team2Score);
+		ratio2Score = 100 - ratio1Score;
+
+		// チーム１＋チーム２＋OTHER＝１００（塗られていない場所含めて比率１００で計算）
+		//float ratio = 100.0f / (team1Score + team2Score + otherColor);
+		//ratio1Score = ratio * team1Score;
+		//ratio2Score = ratio * team2Score;
+		//float noPaint = 100 - (ratio1Score + ratio2Score);
+
+		// Clean up
+		activeCamera.targetTexture = null;
+		RenderTexture.active = null; // added to avoid errors
+		DestroyImmediate(rt);
+
+		Debug.Log("1team:" + ratio1Score);
+		Debug.Log("2team:" + ratio2Score);
+	}
 }
 

--- a/UnityProject/Assets/Script/TeamColor.cs
+++ b/UnityProject/Assets/Script/TeamColor.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu]
+public class TeamColor : ScriptableObject
+{
+    public Color TeamColor1;
+    public Color TeamColor2;
+
+
+
+}

--- a/UnityProject/Assets/Script/TeamColor.cs.meta
+++ b/UnityProject/Assets/Script/TeamColor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: f347a41e6aa91f34f90fefd8b74c127b
+timeCreated: 1508838126
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/ProjectSettings/TagManager.asset
+++ b/UnityProject/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - FadeCanvas
   layers:
   - Default
   - TransparentFX
@@ -13,7 +14,7 @@ TagManager:
   - UI
   - 
   - 
-  - 
+  - Player
   - 
   - 
   - 


### PR DESCRIPTION
## 概要
PixelColorスクリプト追加
OverallCameraプレハブ追加
TeamColorサブスクライブ追加

## 詳細
■PixelColor、OverallCamera
・フィールド上部のフィールド全体を写すカメラ（OverallCamera）からテクスチャを作成し、そのテクスチャのピクセルをすべて取得して色の割合を出す処理
■TeamColor
・チームカラーを2色設定できます。
・ここで設定した色をPixelColorが参照して得点とする色かどうかを見ます。

## 確認方法
ゲーム画面で左クリックするとスクリプトが動きます。

## 見てほしい人
暇ぴーぽー
