### PR TITLE
操作をjoyconに対応

### DIFF
--- a/UnityProject/Assets/Data/PlayerSetteing.asset
+++ b/UnityProject/Assets/Data/PlayerSetteing.asset
@@ -14,5 +14,5 @@ MonoBehaviour:
   maxSpeed: 10
   minSpeed: 2
   acceleration: 0.1
-  acceleSlope: 0.5
+  acceleSlope: 0.9
   DrawAriaSize: 10

--- a/UnityProject/Assets/GameManager.cs
+++ b/UnityProject/Assets/GameManager.cs
@@ -84,7 +84,7 @@ public class GameManager : MonoBehaviour {
         //GameObject.Find("Player_UI_1/Text").GetComponent<Text>().text = "Wait" + Timer;
         //GameObject.Find("Player_UI_2/Text").GetComponent<Text>().text = "Wait" + Timer;
 
-        if (Input.GetKeyDown(KeyCode.Space)||Input.GetButtonDown("Jump"))
+        if (Input.GetKeyDown(KeyCode.Space)||Input.GetButtonDown("Rhythm_1"))
         {
             ClickCnt++;
         }

--- a/UnityProject/Assets/Script/Notes_C.cs
+++ b/UnityProject/Assets/Script/Notes_C.cs
@@ -63,6 +63,12 @@ public class Notes_C : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
+
+
+        for (int i = (int)KeyCode.Joystick1Button0; i <= (int)KeyCode.Joystick8Button19; i++)
+        {
+            if (Input.GetKey((KeyCode)i)) Debug.Log(((KeyCode)i).ToString() + " is pressed.");
+        }
         if (timer.GetTimeOverFlag())
         {
         }
@@ -95,7 +101,7 @@ public class Notes_C : MonoBehaviour
             }
         }
         //ノーツの判定処理部分
-        if (Input.GetKeyDown(KeyCode.Space) || Input.GetButtonDown("Jump"))
+        if (Input.GetKeyDown(KeyCode.Space) || Input.GetButtonDown("Rhythm_" + ((int)playerScript.playerNum + 1)))
         {
             if (FieldNote[0, 0] != null && FieldNote[0, 0].transform.localPosition.x > -50 && FieldNote[0, 0].transform.localPosition.x < 50)
             {
@@ -194,7 +200,6 @@ public class Notes_C : MonoBehaviour
 
             DestoryNote();
         }
-
     }
 
     void SpawnNotes()

--- a/UnityProject/Assets/Script/Player.cs
+++ b/UnityProject/Assets/Script/Player.cs
@@ -67,8 +67,8 @@ public class Player : MonoBehaviour {
         else {
             Debug.Log("param is null");
         }
-        vertical = "Vertical_" + (int)playerNum;
-        horizontal = "Horizontal_" + (int)playerNum;
+        vertical = "Vertical_switch" + ((((int)playerNum - 1) * 2) + 1);
+        horizontal = "Horizontal_switch" + ((((int)playerNum - 1) * 2) + 1);
 
         brush = this.GetComponent<Es.InkPainter.Sample.Paint>();
 
@@ -94,31 +94,44 @@ public class Player : MonoBehaviour {
 
     private void Move ()
     {
-        if (Input.GetKey(KeyCode.UpArrow) || Input.GetAxis(vertical) == 1)
-		{
-            if (moveSpeed < maxSpeed) {
-                moveSpeed += acceleration;
-            }
-            else {
-                moveSpeed = maxSpeed;
-            }
+        //if (Input.GetKey(KeyCode.UpArrow) || Input.GetAxis(horizontal) == 1)
+        //{
+        //    if (moveSpeed < maxSpeed)
+        //    {
+        //        moveSpeed += acceleration;
+        //    }
+        //    else
+        //    {
+        //        moveSpeed = maxSpeed;
+        //    }
 
-		}
+        //}
+        //else
+        //{
+        //    if (minSpeed < moveSpeed)
+        //    {
+        //        moveSpeed -= acceleration;
+        //    }
+        //    else
+        //    {
+        //        moveSpeed = minSpeed;
+        //    }
+        //}
+
+        if (minSpeed < moveSpeed)
+        {
+            moveSpeed -= acceleration;
+        }
         else
-		{
-            if (minSpeed < moveSpeed) {
-                moveSpeed -= acceleration;
-            }
-            else {
-                moveSpeed = minSpeed;
-            }
+        {
+            moveSpeed = minSpeed;
         }
 
-		if (Input.GetKey(KeyCode.LeftArrow) || Input.GetAxis(horizontal) == 1) {
+        if (Input.GetKey(KeyCode.LeftArrow) || Input.GetAxis(vertical) > 0) {
             slope += acceleSlope;
         }
 
-        if (Input.GetKey(KeyCode.RightArrow) || Input.GetAxis(horizontal) == -1) {
+        if (Input.GetKey(KeyCode.RightArrow) || Input.GetAxis(vertical) < 0) {
             slope -= acceleSlope;
         }
 

--- a/UnityProject/ProjectSettings/InputManager.asset
+++ b/UnityProject/ProjectSettings/InputManager.asset
@@ -309,3 +309,195 @@ InputManager:
     type: 0
     axis: 0
     joyNum: 0
+  - serializedVersion: 3
+    m_Name: Horizontal_switch1
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: 
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 0
+    dead: 0.19
+    sensitivity: 1
+    snap: 0
+    invert: 1
+    type: 2
+    axis: 8
+    joyNum: 1
+  - serializedVersion: 3
+    m_Name: Horizontal_switch2
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: 
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 0
+    dead: 0.19
+    sensitivity: 1
+    snap: 0
+    invert: 0
+    type: 2
+    axis: 8
+    joyNum: 2
+  - serializedVersion: 3
+    m_Name: Horizontal_switch3
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: 
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 0
+    dead: 0.19
+    sensitivity: 1
+    snap: 0
+    invert: 1
+    type: 2
+    axis: 8
+    joyNum: 3
+  - serializedVersion: 3
+    m_Name: Horizontal_switch4
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: 
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 0
+    dead: 0.19
+    sensitivity: 1
+    snap: 0
+    invert: 0
+    type: 2
+    axis: 8
+    joyNum: 4
+  - serializedVersion: 3
+    m_Name: Vertical_switch1
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: 
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 0
+    dead: 0.19
+    sensitivity: 1
+    snap: 0
+    invert: 0
+    type: 2
+    axis: 9
+    joyNum: 1
+  - serializedVersion: 3
+    m_Name: Vertical_switch2
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: 
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 0
+    dead: 0.19
+    sensitivity: 1
+    snap: 0
+    invert: 1
+    type: 2
+    axis: 9
+    joyNum: 2
+  - serializedVersion: 3
+    m_Name: Vertical_switch3
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: 
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 0
+    dead: 0.19
+    sensitivity: 1
+    snap: 0
+    invert: 0
+    type: 2
+    axis: 9
+    joyNum: 3
+  - serializedVersion: 3
+    m_Name: Vertical_switch4
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: 
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 0
+    dead: 0.19
+    sensitivity: 1
+    snap: 0
+    invert: 1
+    type: 2
+    axis: 9
+    joyNum: 4
+  - serializedVersion: 3
+    m_Name: Rhythm_1
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick 1 button 15
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 1000
+    dead: 0.001
+    sensitivity: 1000
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 1
+  - serializedVersion: 3
+    m_Name: Rhythm_2
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick 2 button 15
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 1000
+    dead: 0.001
+    sensitivity: 1000
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 2
+  - serializedVersion: 3
+    m_Name: Rhythm_3
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick 3 button 15
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 1000
+    dead: 0.001
+    sensitivity: 1000
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 3
+  - serializedVersion: 3
+    m_Name: Rhythm_4
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: joystick 4 button 15
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 1000
+    dead: 0.001
+    sensitivity: 1000
+    snap: 0
+    invert: 0
+    type: 0
+    axis: 0
+    joyNum: 4


### PR DESCRIPTION
## 概要
・joy-con 1~4Pまで対応
・joy-conはbluetoothで接続
・joy-conは順番に一個ずつ接続しないとjoystickの番号がめちゃくちゃになるので注意。
・番号初期化はunity再起動で可能。